### PR TITLE
Bugfix/swagger UI

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
                 optional: true
             # 2. App-specific configs
             - configMapRef:
-                name: { { .Release.Name } }-config
+                name: {{ .Release.Name }}-config
                 optional: true
             # 3. Environment-wide configs
             - configMapRef:

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,7 @@
 # OpenAPI/Swagger Configuration
 quarkus.smallrye-openapi.path=/openapi
 quarkus.swagger-ui.enable=true
+quarkus.swagger-ui.always-include=${ENABLE_SWAGGER:false}
 quarkus.smallrye-openapi.info-title=PTSS SUPPORT API
 quarkus.smallrye-openapi.info-version=1.0.0
 quarkus.smallrye-openapi.info-description=This is the ptss support api


### PR DESCRIPTION
No value in `.env` or `.env.example` needed since this flag is only relevant for deployed environments. 
Also see [this PR for `feature/swagger-enabling`](https://github.com/PTSS-Support/platform-config/pull/4) in [`platform-config`](https://github.com/PTSS-Support/platform-config). 